### PR TITLE
Error users earlier, avoid 1, >1 difference is XXXMax(k).

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "julia.environmentPath": "/home/leo/.julia/dev/GenericTensorNetworks"
+}

--- a/examples/open.jl
+++ b/examples/open.jl
@@ -1,6 +1,6 @@
-# # Open degrees of freedom
-# Open degrees of freedom is useful when the graph under consideration is an induced subgraph of another graph.
-# The vertices connected to the rest part of the parent graph can not be summed over directly, which can be specified with the `openvertices` keyword argument in the graph problem constructor.
+# # Open and fixed degrees of freedom
+# Open degrees of freedom is useful when one want to get the marginal about certain degrees of freedom.
+# When one specifies the `openvertices` keyword argument in [`solve`](@ref) function as a tuple of vertices, the output will be a tensor that can be indexed by these degrees of freedom.
 # Let us use the maximum independent set problem on Petersen graph as an example.
 #
 using GenericTensorNetworks, Graphs
@@ -8,9 +8,25 @@ using GenericTensorNetworks, Graphs
 graph = Graphs.smallgraph(:petersen)
 
 # The following code computes the MIS tropical tensor (reference to be added) with open vertices 1, 2 and 3.
-problem = IndependentSet(graph; openvertices=[1,2,3])
+problem = IndependentSet(graph; openvertices=[1,2,3]);
 
-mis_tropical_tensor = solve(problem, SizeMax())
+marginal = solve(problem, SizeMax())
 
 # The return value is a rank-3 tensor, with its elements being the MIS sizes under different configuration of open vertices.
 # For the maximum independent set problem, this tensor is also called the MIS tropical tensor, which can be useful in the MIS tropical tensor analysis (reference to be added).
+
+# One can also specify the fixed degrees of freedom by providing the `fixedvertices` keyword argument as a `Dict`, which can be used to get conditioned probability.
+# For example, we can use the following code to do the same calculation as using `openvertices`.
+problem = IndependentSet(graph; fixedvertices=Dict(1=>0, 2=>0, 3=>0));
+
+output = zeros(TropicalF64,2,2,2);
+
+marginal_alternative = map(CartesianIndices((2,2,2))) do ci
+    problem.fixedvertices[1] = ci.I[1]-1
+    problem.fixedvertices[2] = ci.I[2]-1
+    problem.fixedvertices[3] = ci.I[3]-1
+    output[ci] = solve(problem, SizeMax())[]
+end
+
+# One can easily check this one also gets the correct marginal on vertices 1, 2 and 3.
+# As a reminder, their computational hardness can be different, because the contraction order optimization program can optimize over open degrees of freedom.

--- a/src/GenericTensorNetworks.jl
+++ b/src/GenericTensorNetworks.jl
@@ -43,7 +43,7 @@ export SetPacking, is_set_packing
 export SetCovering, is_set_covering
 
 # Interfaces
-export solve, SizeMax, SizeMin, CountingAll, CountingMax, CountingMin, GraphPolynomial, SingleConfigMax, SingleConfigMin, ConfigsAll, ConfigsMax, ConfigsMin
+export solve, SizeMax, SizeMin, CountingAll, CountingMax, CountingMin, GraphPolynomial, SingleConfigMax, SingleConfigMin, ConfigsAll, ConfigsMax, ConfigsMin, Single
 
 # Utilities
 export save_configs, load_configs, hamming_distribution, save_sumproduct, load_sumproduct

--- a/src/configurations.jl
+++ b/src/configurations.jl
@@ -35,12 +35,12 @@ function best_solutions(gp::GraphProblem; all=false, usecuda=false, invert=false
         T = config_type(CountingTropical{T,T}, length(labels(gp)), nflavor(gp); all, tree_storage)
         xs = generate_tensors(_x(T; invert), gp)
         ret = bounding_contract(AllConfigs{1}(), gp.code, xst, ymask, xs)
-        return invert ? post_invert_exponent.(ret) : ret
+        return invert ? asarray(post_invert_exponent.(ret), ret) : ret
     else
         @assert ndims(ymask) == 0
         t, res = solution_ad(gp.code, xst, ymask)
         ret = fill(CountingTropical(asscalar(t).n, ConfigSampler(StaticBitVector(map(l->res[l], 1:length(res))))))
-        return invert ? post_invert_exponent.(ret) : ret
+        return invert ? asarray(post_invert_exponent.(ret), ret) : ret
     end
 end
 
@@ -63,7 +63,7 @@ function solutions(gp::GraphProblem, ::Type{BT}; all::Bool, usecuda::Bool=false,
     end
     T = config_type(BT, length(labels(gp)), nflavor(gp); all, tree_storage)
     ret = contractx(gp, _x(T; invert); usecuda=usecuda)
-    return invert ? post_invert_exponent.(ret) : ret
+    return invert ? asarray(post_invert_exponent.(ret), ret) : ret
 end
 
 """
@@ -79,7 +79,7 @@ function bestk_solutions(gp::GraphProblem, k::Int; invert::Bool=false, tree_stor
     T = config_type(TruncatedPoly{k,T,T}, length(labels(gp)), nflavor(gp); all=true, tree_storage)
     xs = generate_tensors(_x(T; invert), gp)
     ret = bounding_contract(AllConfigs{k}(), gp.code, xst, ymask, xs)
-    return invert ? post_invert_exponent.(ret) : ret
+    return invert ? asarray(post_invert_exponent.(ret), ret) : ret
 end
 
 """

--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -14,7 +14,7 @@ The maximum-K set sizes. e.g. the largest size of the [`IndependentSet`](@ref)  
 * BLAS (on CPU) and GPU are supported only if `K` is `Single`,
 """
 struct SizeMax{K} <: AbstractProperty end
-SizeMax(k::Union{Int,Type{Single}}=Single) = SizeMax{k}()
+SizeMax(k::Union{Int,Type{Single}}=Single) = (@assert k == Single || k > 0; SizeMax{k}())
 max_k(::SizeMax{K}) where K = K
 
 """
@@ -29,7 +29,7 @@ The inverted Tropical number emulates the min-plus tropical number.
 * BLAS (on CPU) and GPU are supported only if `K` is `Single`,
 """
 struct SizeMin{K} <: AbstractProperty end
-SizeMin(k::Union{Int,Type{Single}}=Single) = SizeMin{k}()
+SizeMin(k::Union{Int,Type{Single}}=Single) = (@assert k == Single || k > 0; SizeMin{k}())
 max_k(::SizeMin{K}) where K = K
 
 """
@@ -56,7 +56,7 @@ it counts independent sets of size ``\\alpha(G), \\alpha(G)-1, \\ldots, \\alpha(
 * GPU is supported,
 """
 struct CountingMax{K} <: AbstractProperty end
-CountingMax(K::Union{Int,Type{Single}}=Single) = CountingMax{K}()
+CountingMax(k::Union{Int,Type{Single}}=Single) = (@assert k == Single || k > 0; CountingMax{k}())
 max_k(::CountingMax{K}) where K = K
 
 """
@@ -70,7 +70,7 @@ Counting the number of sets with smallest-K size.
 * GPU is supported,
 """
 struct CountingMin{K} <: AbstractProperty end
-CountingMin(K::Union{Int,Type{Single}}=Single) = CountingMin{K}()
+CountingMin(k::Union{Int,Type{Single}}=Single) = (@assert k == Single || k > 0; CountingMin{k}())
 min_k(::CountingMin{K}) where K = K
 
 """
@@ -126,7 +126,7 @@ Keyword Arguments
 * `bounded`, if it is true, use bounding trick (or boolean gradients) to reduce the working memory to store intermediate configurations.
 """
 struct SingleConfigMax{K,BOUNDED} <:AbstractProperty end
-SingleConfigMax(k::Union{Int,Type{Single}}=Single; bounded::Bool=false) = SingleConfigMax{k, bounded}()
+SingleConfigMax(k::Union{Int,Type{Single}}=Single; bounded::Bool=false) = (@assert k == Single || k > 0; SingleConfigMax{k, bounded}())
 max_k(::SingleConfigMax{K}) where K = K
 
 """
@@ -144,7 +144,7 @@ Keyword Arguments
 * `bounded`, if it is true, use bounding trick (or boolean gradients) to reduce the working memory to store intermediate configurations.
 """
 struct SingleConfigMin{K,BOUNDED} <:AbstractProperty end
-SingleConfigMin(k::Union{Int,Type{Single}}=Single; bounded::Bool=false) = SingleConfigMin{k,bounded}()
+SingleConfigMin(k::Union{Int,Type{Single}}=Single; bounded::Bool=false) = (@assert k == Single || k > 0; SingleConfigMin{k,bounded}())
 min_k(::SingleConfigMin{K}) where K = K
 
 """
@@ -180,7 +180,7 @@ Keyword Arguments
 * `tree_storage`, if it is true, it uses more memory efficient tree-structure to store the configurations.
 """
 struct ConfigsMax{K, BOUNDED, TREESTORAGE} <:AbstractProperty end
-ConfigsMax(K::Union{Int,Type{Single}}=Single; bounded::Bool=true, tree_storage::Bool=false) = ConfigsMax{K,bounded,tree_storage}()
+ConfigsMax(k::Union{Int,Type{Single}}=Single; bounded::Bool=true, tree_storage::Bool=false) = (@assert k == Single || k > 0; ConfigsMax{k,bounded,tree_storage}())
 max_k(::ConfigsMax{K}) where K = K
 tree_storage(::ConfigsMax{K,BOUNDED,TREESTORAGE}) where {K,BOUNDED,TREESTORAGE} = TREESTORAGE
 
@@ -199,7 +199,7 @@ Keyword Arguments
 * `tree_storage`, if it is true, it uses more memory efficient tree-structure to store the configurations.
 """
 struct ConfigsMin{K, BOUNDED, TREESTORAGE} <:AbstractProperty end
-ConfigsMin(K::Union{Int,Type{Single}}=Single; bounded::Bool=true, tree_storage::Bool=false) = ConfigsMin{K,bounded, tree_storage}()
+ConfigsMin(k::Union{Int,Type{Single}}=Single; bounded::Bool=true, tree_storage::Bool=false) = (@assert k == Single || k > 0; ConfigsMin{k,bounded, tree_storage}())
 min_k(::ConfigsMin{K}) where K = K
 tree_storage(::ConfigsMin{K,BOUNDED,TREESTORAGE}) where {K,BOUNDED,TREESTORAGE} = TREESTORAGE
 

--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -1,4 +1,7 @@
 abstract type AbstractProperty end
+struct Single end
+_asint(x::Integer) = x
+_asint(x::Type{Single}) = 1
 
 """
     SizeMax{K} <: AbstractProperty
@@ -6,12 +9,12 @@ abstract type AbstractProperty end
 
 The maximum-K set sizes. e.g. the largest size of the [`IndependentSet`](@ref)  problem is also know as the independence number.
 
-* The corresponding tensor element type are max-plus tropical number [`Tropical`](@ref) for `K == 1` and [`ExtendedTropical`](@ref) for `K > 1`.
+* The corresponding tensor element type are max-plus tropical number [`Tropical`](@ref) if `K` is `Single` and [`ExtendedTropical`](@ref) if `K` is an integer.
 * It is compatible with weighted graph problems.
-* BLAS (on CPU) and GPU are supported only for `K == 1`,
+* BLAS (on CPU) and GPU are supported only if `K` is `Single`,
 """
 struct SizeMax{K} <: AbstractProperty end
-SizeMax(k::Int=1) = SizeMax{k}()
+SizeMax(k::Union{Int,Type{Single}}=Single) = SizeMax{k}()
 max_k(::SizeMax{K}) where K = K
 
 """
@@ -20,13 +23,13 @@ max_k(::SizeMax{K}) where K = K
 
 The minimum-K set sizes. e.g. the smallest size ofthe [`MaximalIS`](@ref) problem is also known as the independent domination number.
 
-* The corresponding tensor element type are inverted max-plus tropical number [`Tropical`](@ref) for `K == 1` and inverted [`ExtendedTropical`](@ref) for `K > 1`.
+* The corresponding tensor element type are inverted max-plus tropical number [`Tropical`](@ref) if `K` is `Single` and inverted [`ExtendedTropical`](@ref) `K` is an integer.
 The inverted Tropical number emulates the min-plus tropical number.
 * It is compatible with weighted graph problems.
-* BLAS (on CPU) and GPU are supported only for `K == 1`,
+* BLAS (on CPU) and GPU are supported only if `K` is `Single`,
 """
 struct SizeMin{K} <: AbstractProperty end
-SizeMin(k::Int=1) = SizeMin{k}()
+SizeMin(k::Union{Int,Type{Single}}=Single) = SizeMin{k}()
 max_k(::SizeMin{K}) where K = K
 
 """
@@ -43,31 +46,31 @@ struct CountingAll <: AbstractProperty end
 
 """
     CountingMax{K} <: AbstractProperty
-    CountingMax(K=1)
+    CountingMax(K=Single)
 
 Counting the number of sets with largest-K size. e.g. for [`IndependentSet`](@ref) problem,
 it counts independent sets of size ``\\alpha(G), \\alpha(G)-1, \\ldots, \\alpha(G)-K+1``.
 
-* The corresponding tensor element type is [`CountingTropical`](@ref) for `K == 1`, and [`TruncatedPoly`](@ref)`{K}` for `K > 1`.
-* Weighted graph problems is only supported for `K == 1`.
+* The corresponding tensor element type is [`CountingTropical`](@ref) if `K` is `Single`, and [`TruncatedPoly`](@ref)`{K}` if `K` is an integer.
+* Weighted graph problems is only supported if `K` is `Single`.
 * GPU is supported,
 """
 struct CountingMax{K} <: AbstractProperty end
-CountingMax(K::Int=1) = CountingMax{K}()
+CountingMax(K::Union{Int,Type{Single}}=Single) = CountingMax{K}()
 max_k(::CountingMax{K}) where K = K
 
 """
     CountingMin{K} <: AbstractProperty
-    CountingMin(K=1)
+    CountingMin(K=Single)
 
 Counting the number of sets with smallest-K size.
 
-* The corresponding tensor element type is inverted [`CountingTropical`](@ref) for `K == 1`, and [`TruncatedPoly`](@ref)`{K}` for `K > 1`.
-* Weighted graph problems is only supported for `K == 1`.
+* The corresponding tensor element type is inverted [`CountingTropical`](@ref) if `K` is `Single`, and [`TruncatedPoly`](@ref)`{K}` if `K` is an integer.
+* Weighted graph problems is only supported if `K` is `Single`.
 * GPU is supported,
 """
 struct CountingMin{K} <: AbstractProperty end
-CountingMin(K::Int=1) = CountingMin{K}()
+CountingMin(K::Union{Int,Type{Single}}=Single) = CountingMin{K}()
 min_k(::CountingMin{K}) where K = K
 
 """
@@ -123,7 +126,7 @@ Keyword Arguments
 * `bounded`, if it is true, use bounding trick (or boolean gradients) to reduce the working memory to store intermediate configurations.
 """
 struct SingleConfigMax{K,BOUNDED} <:AbstractProperty end
-SingleConfigMax(k::Int=1; bounded::Bool=false) = SingleConfigMax{k, bounded}()
+SingleConfigMax(k::Union{Int,Type{Single}}=Single; bounded::Bool=false) = SingleConfigMax{k, bounded}()
 max_k(::SingleConfigMax{K}) where K = K
 
 """
@@ -141,7 +144,7 @@ Keyword Arguments
 * `bounded`, if it is true, use bounding trick (or boolean gradients) to reduce the working memory to store intermediate configurations.
 """
 struct SingleConfigMin{K,BOUNDED} <:AbstractProperty end
-SingleConfigMin(k::Int=1; bounded::Bool=false) = SingleConfigMin{k,bounded}()
+SingleConfigMin(k::Union{Int,Type{Single}}=Single; bounded::Bool=false) = SingleConfigMin{k,bounded}()
 min_k(::SingleConfigMin{K}) where K = K
 
 """
@@ -163,13 +166,13 @@ tree_storage(::ConfigsAll{TREESTORAGE}) where {TREESTORAGE} = TREESTORAGE
 
 """
     ConfigsMax{K, BOUNDED, TREESTORAGE} <:AbstractProperty
-    ConfigsMax(K=Extrema(); bounded=true, tree_storage=true)
+    ConfigsMax(K=Single; bounded=true, tree_storage=true)
 
 Find configurations with largest-K sizes, e.g. for [`IndependentSet`](@ref) problem,
 it is finding all independent sets of sizes ``\\alpha(G), \\alpha(G)-1, \\ldots, \\alpha(G)-K+1``.
 
-* The corresponding data type is [`CountingTropical`](@ref)`{Float64,<:ConfigEnumerator}` for `K == Extrema()` and [`TruncatedPoly`](@ref)`{K,<:ConfigEnumerator}` for `K` being an integer.
-* Weighted graph problems is only supported for `K == Extrema()`.
+* The corresponding data type is [`CountingTropical`](@ref)`{Float64,<:ConfigEnumerator}` if `K` is `Single` and [`TruncatedPoly`](@ref)`{K,<:ConfigEnumerator}` if `K` is an integer.
+* Weighted graph problems is only supported if `K` is `Single`.
 
 Keyword Arguments
 ----------------------------
@@ -177,18 +180,18 @@ Keyword Arguments
 * `tree_storage`, if it is true, it uses more memory efficient tree-structure to store the configurations.
 """
 struct ConfigsMax{K, BOUNDED, TREESTORAGE} <:AbstractProperty end
-ConfigsMax(K::Int=1; bounded::Bool=true, tree_storage::Bool=false) = ConfigsMax{K,bounded,tree_storage}()
+ConfigsMax(K::Union{Int,Type{Single}}=Single; bounded::Bool=true, tree_storage::Bool=false) = ConfigsMax{K,bounded,tree_storage}()
 max_k(::ConfigsMax{K}) where K = K
 tree_storage(::ConfigsMax{K,BOUNDED,TREESTORAGE}) where {K,BOUNDED,TREESTORAGE} = TREESTORAGE
 
 """
     ConfigsMin{K, BOUNDED, TREESTORAGE} <:AbstractProperty
-    ConfigsMin(K=1; bounded=true, tree_storage=false)
+    ConfigsMin(K=Single; bounded=true, tree_storage=false)
 
 Find configurations with smallest-K sizes.
 
-* The corresponding data type is inverted [`CountingTropical`](@ref)`{Float64,<:ConfigEnumerator}` for `K == 1` and inverted [`TruncatedPoly`](@ref)`{K,<:ConfigEnumerator}` for `K > 1`.
-* Weighted graph problems is only supported for `K == 1`.
+* The corresponding data type is inverted [`CountingTropical`](@ref)`{Float64,<:ConfigEnumerator}` if `K` is `Single` and inverted [`TruncatedPoly`](@ref)`{K,<:ConfigEnumerator}` if `K` is an integer.
+* Weighted graph problems is only supported if `K` is `Single`.
 
 Keyword Arguments
 ----------------------------
@@ -196,7 +199,7 @@ Keyword Arguments
 * `tree_storage`, if it is true, it uses more memory efficient tree-structure to store the configurations.
 """
 struct ConfigsMin{K, BOUNDED, TREESTORAGE} <:AbstractProperty end
-ConfigsMin(K::Int=1; bounded::Bool=true, tree_storage::Bool=false) = ConfigsMin{K,bounded, tree_storage}()
+ConfigsMin(K::Union{Int,Type{Single}}=Single; bounded::Bool=true, tree_storage::Bool=false) = ConfigsMin{K,bounded, tree_storage}()
 min_k(::ConfigsMin{K}) where K = K
 tree_storage(::ConfigsMin{K,BOUNDED,TREESTORAGE}) where {K,BOUNDED,TREESTORAGE} = TREESTORAGE
 
@@ -210,18 +213,18 @@ Positional Arguments
 * `problem` is the graph problem with tensor network information,
 * `property` is string specifying the task. Using the maximum independent set problem as an example, it can be one of
 
-    * [`SizeMax`](@ref)`(k=1)` for finding ``k`` maximum set size,
-    * [`SizeMin`](@ref)`(k=1)` for finding ``k`` minimum set size,
+    * [`SizeMax`](@ref)`(k=Single)` for finding maximum-``k`` set sizes,
+    * [`SizeMin`](@ref)`(k=Single)` for finding minimum-``k`` set sizes,
 
-    * [`CountingMax`](@ref)`(k=1)` for counting configurations with maximum-``k`` sizes,
-    * [`CountingMin`](@ref)`(k=1)` for counting configurations with minimum-``k`` sizes,
+    * [`CountingMax`](@ref)`(k=Single)` for counting configurations with maximum-``k`` sizes,
+    * [`CountingMin`](@ref)`(k=Single)` for counting configurations with minimum-``k`` sizes,
     * [`CountingAll`](@ref)`()` for counting all configurations,
     * [`GraphPolynomial`](@ref)`(; method=:finitefield, kwargs...)` for evaluating the graph polynomial,
 
-    * [`SingleConfigMax`](@ref)`(k=1; bounded=false)` for finding one maximum-``k`` configuration for each size,
-    * [`SingleConfigMin`](@ref)`(k=1; bounded=false)` for finding one minimum-``k`` configuration for each size,
-    * [`ConfigsMax`](@ref)`(k=1; bounded=true, tree_storage=false)` for enumerating configurations with maximum-``k`` sizes,
-    * [`ConfigsMin`](@ref)`(k=1; bounded=true, tree_storage=false)` for enumerating configurations with minimum-``k`` sizes,
+    * [`SingleConfigMax`](@ref)`(k=Single; bounded=false)` for finding one maximum-``k`` configuration for each size,
+    * [`SingleConfigMin`](@ref)`(k=Single; bounded=false)` for finding one minimum-``k`` configuration for each size,
+    * [`ConfigsMax`](@ref)`(k=Single; bounded=true, tree_storage=false)` for enumerating configurations with maximum-``k`` sizes,
+    * [`ConfigsMin`](@ref)`(k=Single; bounded=true, tree_storage=false)` for enumerating configurations with minimum-``k`` sizes,
     * [`ConfigsAll`](@ref)`(; tree_storage=false)` for enumerating all configurations,
 
 
@@ -232,9 +235,9 @@ Keyword arguments
 """
 function solve(gp::GraphProblem, property::AbstractProperty; T=Float64, usecuda=false)
     assert_solvable(gp, property)
-    if property isa SizeMax{1}
+    if property isa SizeMax{Single}
         return contractx(gp, _x(Tropical{T}; invert=false); usecuda=usecuda)
-    elseif property isa SizeMin{1}
+    elseif property isa SizeMin{Single}
         res = contractx(gp, _x(Tropical{T}; invert=true); usecuda=usecuda)
         return asarray(post_invert_exponent.(res), res)
     elseif property isa SizeMax
@@ -244,9 +247,9 @@ function solve(gp::GraphProblem, property::AbstractProperty; T=Float64, usecuda=
         return asarray(post_invert_exponent.(res), res)
     elseif property isa CountingAll
         return contractx(gp, one(T); usecuda=usecuda)
-    elseif property isa CountingMax{1}
+    elseif property isa CountingMax{Single}
         return contractx(gp, _x(CountingTropical{T,T}; invert=false); usecuda=usecuda)
-    elseif property isa CountingMin{1}
+    elseif property isa CountingMin{Single}
         res = contractx(gp, _x(CountingTropical{T,T}; invert=true); usecuda=usecuda)
         return asarray(post_invert_exponent.(res), res)
     elseif property isa CountingMax
@@ -256,17 +259,17 @@ function solve(gp::GraphProblem, property::AbstractProperty; T=Float64, usecuda=
         return asarray(post_invert_exponent.(res), res)
     elseif property isa GraphPolynomial
         return graph_polynomial(gp, Val(graph_polynomial_method(property)); usecuda=usecuda, T=T, property.kwargs...)
-    elseif property isa SingleConfigMax{1,false}
+    elseif property isa SingleConfigMax{Single,false}
         return solutions(gp, CountingTropical{T,T}; all=false, usecuda=usecuda)
     elseif property isa (SingleConfigMax{K,false} where K)
         return solutions(gp, ExtendedTropical{max_k(property),CountingTropical{T,T}}; all=false, usecuda=usecuda)
-    elseif property isa SingleConfigMin{1,false}
+    elseif property isa SingleConfigMin{Single,false}
         return solutions(gp, CountingTropical{T,T}; all=false, usecuda=usecuda, invert=true)
     elseif property isa (SingleConfigMin{K,false} where K)
         return solutions(gp, ExtendedTropical{min_k(property),CountingTropical{T,T}}; all=false, usecuda=usecuda, invert=true)
-    elseif property isa ConfigsMax{1,false}
+    elseif property isa ConfigsMax{Single,false}
         return solutions(gp, CountingTropical{T,T}; all=true, usecuda=usecuda, tree_storage=tree_storage(property))
-    elseif property isa ConfigsMin{1,false}
+    elseif property isa ConfigsMin{Single,false}
         return solutions(gp, CountingTropical{T,T}; all=true, usecuda=usecuda, invert=true, tree_storage=tree_storage(property))
     elseif property isa (ConfigsMax{K, false} where K)
         return solutions(gp, TruncatedPoly{max_k(property),T,T}; all=true, usecuda=usecuda, tree_storage=tree_storage(property))
@@ -274,19 +277,19 @@ function solve(gp::GraphProblem, property::AbstractProperty; T=Float64, usecuda=
         return solutions(gp, TruncatedPoly{min_k(property),T,T}; all=true, usecuda=usecuda, invert=true)
     elseif property isa ConfigsAll
         return solutions(gp, Real; all=true, usecuda=usecuda, tree_storage=tree_storage(property))
-    elseif property isa SingleConfigMax{1,true}
+    elseif property isa SingleConfigMax{Single,true}
         return best_solutions(gp; all=false, usecuda=usecuda, T=T)
     elseif property isa (SingleConfigMax{K,true} where K)
-        @warn "bounded `SingleConfigMax` property for `K != 1` is not implemented. Switching to the unbounded version."
+        @warn "bounded `SingleConfigMax` property for `K != Single` is not implemented. Switching to the unbounded version."
         return solve(gp, SingleConfigMax{max_k(property),false}(); T, usecuda)
-    elseif property isa SingleConfigMin{1,true}
+    elseif property isa SingleConfigMin{Single,true}
         return best_solutions(gp; all=false, usecuda=usecuda, invert=true, T=T)
     elseif property isa (SingleConfigMin{K,true} where K)
-        @warn "bounded `SingleConfigMin` property for `K != 1` is not implemented. Switching to the unbounded version."
+        @warn "bounded `SingleConfigMin` property for `K != Single` is not implemented. Switching to the unbounded version."
         return solve(gp, SingleConfigMin{min_k(property),false}(); T, usecuda)
-    elseif property isa ConfigsMax{1,true}
+    elseif property isa ConfigsMax{Single,true}
         return best_solutions(gp; all=true, usecuda=usecuda, tree_storage=tree_storage(property), T=T)
-    elseif property isa ConfigsMin{1,true}
+    elseif property isa ConfigsMin{Single,true}
         return best_solutions(gp; all=true, usecuda=usecuda, invert=true, tree_storage=tree_storage(property), T=T)
     elseif property isa (ConfigsMax{K,true} where K)
         return bestk_solutions(gp, max_k(property), tree_storage=tree_storage(property), T=T)
@@ -305,22 +308,22 @@ function assert_solvable(problem, property::GraphPolynomial)
     end
 end
 function assert_solvable(problem, property::ConfigsMax)
-    if max_k(property) != 1 && has_noninteger_weights(problem)
+    if max_k(property) != Single && has_noninteger_weights(problem)
         throw(ArgumentError("Graph property `$(typeof(property))` is not computable due to having non-integer weights. Maybe you wanted `SingleConfigMax($(max_k(property)))`?"))
     end
 end
 function assert_solvable(problem, property::ConfigsMin)
-    if min_k(property) != 1 && has_noninteger_weights(problem)
+    if min_k(property) != Single && has_noninteger_weights(problem)
         throw(ArgumentError("Graph property `$(typeof(property))` is not computable due to having non-integer weights. Maybe you wanted `SingleConfigMin($(min_k(property)))`?"))
     end
 end
 function assert_solvable(problem, property::CountingMax)
-    if max_k(property) != 1 && has_noninteger_weights(problem)
+    if max_k(property) != Single && has_noninteger_weights(problem)
         throw(ArgumentError("Graph property `$(typeof(property))` is not computable due to having non-integer weights. Maybe you wanted `SizeMax($(max_k(property)))`?"))
     end
 end
 function assert_solvable(problem, property::CountingMin)
-    if min_k(property) != 1 && has_noninteger_weights(problem)
+    if min_k(property) != Single && has_noninteger_weights(problem)
         throw(ArgumentError("Graph property `$(typeof(property))` is not computable due to having non-integer weights. Maybe you wanted `SizeMin($(min_k(property)))`?"))
     end
 end
@@ -362,16 +365,16 @@ end
 function estimate_memory(problem::GraphProblem, property::Union{SingleConfigMax{K,BOUNDED},SingleConfigMin{K,BOUNDED}}; T=Float64) where {K, BOUNDED}
     tc, sc, rw = timespacereadwrite_complexity(problem.code, _size_dict(problem))
     # caching all tensors is equivalent to counting the total number of writes
-    if K == 1 && BOUNDED
+    if K === Single && BOUNDED
         return ceil(Int, exp2(rw - 1)) * sizeof(Tropical{T})
-    elseif K == 1 & !BOUNDED
+    elseif K === Single && !BOUNDED
         n, nf = length(labels(problem)), nflavor(problem)
-        return peak_memory(problem.code, _size_dict(problem)) * (sizeof(tensor_element_type(T, n, nf, property)) * K)
+        return peak_memory(problem.code, _size_dict(problem)) * (sizeof(tensor_element_type(T, n, nf, property)))
     else
-        # NOTE: the `K > 1` case does not respect bounding
+        # NOTE: the integer `K` case does not respect bounding
         n, nf = length(labels(problem)), nflavor(problem)
         TT = tensor_element_type(T, n, nf, property)
-        return peak_memory(problem.code, _size_dict(problem)) * (sizeof(tensor_element_type(T, n, nf, SingleConfigMax{1,BOUNDED}())) * K + sizeof(TT))
+        return peak_memory(problem.code, _size_dict(problem)) * (sizeof(tensor_element_type(T, n, nf, SingleConfigMax{Single,BOUNDED}())) * K + sizeof(TT))
     end
 end
 function estimate_memory(problem::GraphProblem, ::GraphPolynomial{:polynomial}; T=Float64)
@@ -379,7 +382,7 @@ function estimate_memory(problem::GraphProblem, ::GraphPolynomial{:polynomial}; 
     return peak_memory(problem.code, _size_dict(problem)) * (sizeof(T) * length(labels(problem)))
 end
 function estimate_memory(problem::GraphProblem, ::Union{SizeMax{K},SizeMin{K}}; T=Float64) where K
-    return peak_memory(problem.code, _size_dict(problem)) * (sizeof(T) * K)
+    return peak_memory(problem.code, _size_dict(problem)) * (sizeof(T) * _asint(K))
 end
 
 function _size_dict(problem)
@@ -396,9 +399,9 @@ function _estimate_memory(::Type{ET}, problem::GraphProblem) where ET
 end
 
 for (PROP, ET) in [
-        (:(SizeMax{1}), :(Tropical{T})), (:(SizeMin{1}), :(Tropical{T})),
+        (:(SizeMax{Single}), :(Tropical{T})), (:(SizeMin{Single}), :(Tropical{T})),
         (:(SizeMax{K}), :(ExtendedTropical{K,Tropical{T}})), (:(SizeMin{K}), :(ExtendedTropical{K,Tropical{T}})),
-        (:(CountingAll), :T), (:(CountingMax{1}), :(CountingTropical{T,T})), (:(CountingMin{1}), :(CountingTropical{T,T})),
+        (:(CountingAll), :T), (:(CountingMax{Single}), :(CountingTropical{T,T})), (:(CountingMin{Single}), :(CountingTropical{T,T})),
         (:(CountingMax{K}), :(TruncatedPoly{K,T,T})), (:(CountingMin{K}), :(TruncatedPoly{K,T,T})),
         (:(GraphPolynomial{:finitefield}), :(Mod{N,Int32} where N)), (:(GraphPolynomial{:fft}), :(Complex{T})), 
         (:(GraphPolynomial{:polynomial}), :(Polynomial{T, :x})), (:(GraphPolynomial{:fitting}), :T),
@@ -407,18 +410,18 @@ for (PROP, ET) in [
 end
 
 function tensor_element_type(::Type{T}, n::Int, nflavor::Int, ::PROP) where {T, K, BOUNDED, PROP<:Union{SingleConfigMax{K,BOUNDED},SingleConfigMin{K,BOUNDED}}}
-    if K == 1 && BOUNDED
+    if K === Single && BOUNDED
         return Tropical{T}
-    elseif K == 1 && !BOUNDED
+    elseif K === Single && !BOUNDED
         return sampler_type(CountingTropical{T,T}, n, nflavor)
     else
-        # NOTE: the `K > 1` case does not respect bounding
+        # NOTE: the integer `K` case does not respect bounding
         return sampler_type(ExtendedTropical{K,CountingTropical{T,T}}, n, nflavor)
     end
 end
 
 for (PROP, ET) in [
-        (:(ConfigsMax{1}), :(CountingTropical{T,T})), (:(ConfigsMin{1}), :(CountingTropical{T,T})),
+        (:(ConfigsMax{Single}), :(CountingTropical{T,T})), (:(ConfigsMin{Single}), :(CountingTropical{T,T})),
         (:(ConfigsMax{K}), :(TruncatedPoly{K,T,T})), (:(ConfigsMin{K}), :(TruncatedPoly{K,T,T})),
         (:(ConfigsAll), :(Real))
     ]

--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -163,13 +163,13 @@ tree_storage(::ConfigsAll{TREESTORAGE}) where {TREESTORAGE} = TREESTORAGE
 
 """
     ConfigsMax{K, BOUNDED, TREESTORAGE} <:AbstractProperty
-    ConfigsMax(K=1; bounded=true, tree_storage=true)
+    ConfigsMax(K=Extrema(); bounded=true, tree_storage=true)
 
 Find configurations with largest-K sizes, e.g. for [`IndependentSet`](@ref) problem,
 it is finding all independent sets of sizes ``\\alpha(G), \\alpha(G)-1, \\ldots, \\alpha(G)-K+1``.
 
-* The corresponding data type is [`CountingTropical`](@ref)`{Float64,<:ConfigEnumerator}` for `K == 1` and [`TruncatedPoly`](@ref)`{K,<:ConfigEnumerator}` for `K > 1`.
-* Weighted graph problems is only supported for `K == 1`.
+* The corresponding data type is [`CountingTropical`](@ref)`{Float64,<:ConfigEnumerator}` for `K == Extrema()` and [`TruncatedPoly`](@ref)`{K,<:ConfigEnumerator}` for `K` being an integer.
+* Weighted graph problems is only supported for `K == Extrema()`.
 
 Keyword Arguments
 ----------------------------

--- a/test/interfaces.jl
+++ b/test/interfaces.jl
@@ -193,4 +193,5 @@ end
     @test solve(gp, ConfigsMax(Single)) isa Array
     @test_throws ArgumentError solve(gp, ConfigsMin(2))
     @test solve(gp, ConfigsMin(Single)) isa Array
+    @test_throws AssertionError ConfigsMin(0)
 end

--- a/test/interfaces.jl
+++ b/test/interfaces.jl
@@ -7,7 +7,7 @@ using Graphs, Test
         gp = IndependentSet(g; optimizer=optimizer)
         res1 = solve(gp, SizeMax())[]
         res2 = solve(gp, CountingAll())[]
-        res3 = solve(gp, CountingMax(1))[]
+        res3 = solve(gp, CountingMax(Single))[]
         res4 = solve(gp, CountingMax(2))[]
         res5 = solve(gp, GraphPolynomial(; method = :polynomial))[]
         res6 = solve(gp, SingleConfigMax())[]
@@ -49,7 +49,7 @@ end
     gp = IndependentSet(g; optimizer=TreeSA(nslices=5, ntrials=1))
     res1 = solve(gp, SizeMax())[]
     res2 = solve(gp, CountingAll())[]
-    res3 = solve(gp, CountingMax(1))[]
+    res3 = solve(gp, CountingMax(Single))[]
     res4 = solve(gp, CountingMax(2))[]
     res5 = solve(gp, GraphPolynomial(; method = :polynomial))[]
     res6 = solve(gp, SingleConfigMax())[]
@@ -90,7 +90,7 @@ end
     gp = IndependentSet(g; weights=collect(1:10))
     res1 = solve(gp, SizeMax())[]
     @test res1 == Tropical(24.0)
-    res2 = solve(gp, CountingMax(1))[]
+    res2 = solve(gp, CountingMax(Single))[]
     @test res2 == CountingTropical(24.0, 1.0)
     res2b = solve(gp, CountingMax(2))[]
     @test res2b == Max2Poly(1.0, 1.0, 24.0)
@@ -98,8 +98,8 @@ end
     res3b = solve(gp, SingleConfigMax(; bounded=true))[]
     @test res3 == res3b
     @test sum(collect(res3.c.data) .* (1:10))  == 24.0
-    res4 = solve(gp, ConfigsMax(1; bounded=false))[]
-    res4b = solve(gp, ConfigsMax(1; bounded=true))[]
+    res4 = solve(gp, ConfigsMax(Single; bounded=false))[]
+    res4b = solve(gp, ConfigsMax(Single; bounded=true))[]
     @test res4 == res4b
     @test res4.c.data[] == res3.c.data
 
@@ -186,11 +186,11 @@ end
     @test GenericTensorNetworks.has_noninteger_weights(gp)
     @test_throws ArgumentError solve(gp, GraphPolynomial())
     @test_throws ArgumentError solve(gp, CountingMax(2))
-    @test solve(gp, CountingMax(1)) isa Array
+    @test solve(gp, CountingMax(Single)) isa Array
     @test_throws ArgumentError solve(gp, ConfigsMax(2))
-    @test solve(gp, CountingMin(1)) isa Array
+    @test solve(gp, CountingMin(Single)) isa Array
     @test_throws ArgumentError solve(gp, ConfigsMin(2))
-    @test solve(gp, ConfigsMax(1)) isa Array
+    @test solve(gp, ConfigsMax(Single)) isa Array
     @test_throws ArgumentError solve(gp, ConfigsMin(2))
-    @test solve(gp, ConfigsMin(1)) isa Array
+    @test solve(gp, ConfigsMin(Single)) isa Array
 end

--- a/test/interfaces.jl
+++ b/test/interfaces.jl
@@ -178,3 +178,19 @@ end
     @test estimate_memory(gp, GraphPolynomial(method=:fitting); T=Float32) * 4 == estimate_memory(gp, GraphPolynomial(method=:fft))
     @test estimate_memory(gp, GraphPolynomial(method=:finitefield)) * 10 == estimate_memory(gp, GraphPolynomial(method=:polynomial); T=Float32)
 end
+
+@testset "error on not solvable problems" begin
+    gp = IndependentSet(smallgraph(:petersen); weights=rand(1:3, 10))
+    @test !GenericTensorNetworks.has_noninteger_weights(gp)
+    gp = IndependentSet(smallgraph(:petersen); weights=rand(10))
+    @test GenericTensorNetworks.has_noninteger_weights(gp)
+    @test_throws ArgumentError solve(gp, GraphPolynomial())
+    @test_throws ArgumentError solve(gp, CountingMax(2))
+    @test solve(gp, CountingMax(1)) isa Array
+    @test_throws ArgumentError solve(gp, ConfigsMax(2))
+    @test solve(gp, CountingMin(1)) isa Array
+    @test_throws ArgumentError solve(gp, ConfigsMin(2))
+    @test solve(gp, ConfigsMax(1)) isa Array
+    @test_throws ArgumentError solve(gp, ConfigsMin(2))
+    @test solve(gp, ConfigsMin(1)) isa Array
+end


### PR DESCRIPTION
Now if the input is an integer, it always return a `TruncatedPoly` type.
```julia
julia> ConfigsMax()
ConfigsMax{Single, true, false}()

julia> ConfigsMax(1)
ConfigsMax{1, true, false}()

julia> gp = IndependentSet(smallgraph(:petersen));

julia> solve(gp, ConfigsMax(1))
0-dimensional Array{TruncatedPoly{1, ConfigEnumerator{10, 1, 1}, Float64}, 0}:
{0010111000, 1010000011, 0100100110, 0101010001, 1001001100}*x^4
```

It also error users at input if the property if not computable
```julia
julia> gp = IndependentSet(smallgraph(:petersen); weights=rand(10));

julia> solve(gp, ConfigsMax(2))
ERROR: ArgumentError: Graph property `ConfigsMax{2, true, false}` is not computable due to having non-integer weights. Maybe you wanted `SingleConfigMax(2)`?

julia> solve(gp, ConfigsMax(0))
ERROR: AssertionError: k == Single || k > 0
```

Also updated some documentation.