### PR TITLE
Fix Base.hash to use only the two-arg method

### DIFF
--- a/src/Mods.jl/src/Mods.jl
+++ b/src/Mods.jl/src/Mods.jl
@@ -62,7 +62,7 @@ value(a::Mod{N}) where {N} = mod(a.val, N)
 
 Base.abs(a::Mod{N,<:Real} where {N}) = abs(value(a))
 
-function hash(x::Mod, h::UInt64 = UInt64(0))
+function hash(x::Mod, h::UInt)
     v = value(x)
     m = modulus(x)
     return hash(v, hash(m, h))


### PR DESCRIPTION
Generated as part of an ecosystem-wide audit for one-arg hash methods.

`Base.hash` should only be extended via the two-arg method `hash(x, h::UInt)`.
Defining a one-arg `hash(x)` method, or giving the second argument a default
value, can lead to correctness bugs (hash contract violations when the seed
differs from the hard-coded default) and invalidation-related performance
issues. This is particularly necessary for Julia 1.13+ where the default hash
seed value will change.

This PR was generated with the assistance of generative AI.